### PR TITLE
CII Best Practices

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,27 @@ Closes: #
 What problem does this pull request solve? This should be close to the goal of the issue this pull request addresses.
 
 # Approach
-1. Describe the approach you chose to solve the above problem.
-2. This will help code reviewers get oriented quickly.
-3. It will also document for future maintainers exactly what changed (and why) when this PR was merged.
+1. **Describe, in numbered steps, the approach you chose** to solve the above problem.
+    1. This will help code reviewers get oriented quickly.
+    2. It will also document for future maintainers exactly what changed (and why) when this PR was merged.
+2. **Add specs** that either *reproduce the bug* or *cover the new feature*. In the former's case, *make sure it fails without the fix!*
+3. Document any new public methods using standard RDoc syntax, or update the existing RDoc for any modified public methods. As an example, see the RDoc for `Location.find_or_init`:
+
+```ruby
+  # Finds or initializes the Location with the specified attributes.
+  #
+  # @param attr [Hash] the attributes for the Location
+  # @return [Location] the found or initialized Location
+  # @example
+  #   Location.find_or_init({ la_id: '1', address1: '1261 W 79th Street' })
+  def self.find_or_init(attr)
+    la_id = attr.delete('id') || attr.delete('c')
+    attr.delete('lat-lon') # delete duplicate key
+    location = find_by_best_key(la_id: la_id, address1: attr['addr1']) || Location.new(la_id: la_id)
+    common_keys = location.attributes.keys & attr.keys
+    common_keys.each { |key| location[key] = attr[key] }
+    location
+  end
+```
+
+Signed-off-by: YOUR NAME <YOUR.EMAIL@EXAMPLE.COM>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+[Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates) automatically [patches known vulnerabilities](https://github.com/FoveaCentral/vaccinesignup/pulls?q=is%3Apr+is%3Aclosed+author%3Aapp%2Fdependabot).
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.0.5   | :white_check_mark: |
+| < 1.0.5 | :x:                |
+
+## Reporting a Vulnerability
+
+1. To report a security vulnerability, [open an issue](https://github.com/FoveaCentral/vaccinesignup/issues/new/choose).
+2. Updates are made within 48 hours.
+3. If the vulnerability is accepted, we'll try to patch it within a week.


### PR DESCRIPTION
Closes: n/a

# Goal
Observe the Linux Foundation's CII [Best Practices](https://bestpractices.coreinfrastructure.org/en/projects/5405).

# Approach
1. Add:
    1. a pull-request template
    2. security policy