### PR TITLE
CI: Inch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,5 +34,7 @@ jobs:
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Rubocop
-      run: bundle ex rubocop
+    - name: Run RuboCop
+      run: bundle exec rubocop
+    - name: Run Inch
+      run: bundle exec inch --pedantic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
   test:
     environment: staging
     runs-on: ubuntu-latest
+    name: Ruby ${{ matrix.ruby-version }}
     strategy:
       matrix:
         ruby-version: [2.7]
@@ -20,13 +21,16 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
-    - name: Install dependencies
-      run: bundle install
     - name: Prepare db
       run: bundle exec rake db:prepare RAILS_ENV=test
     - name: Run tests
       run: bundle exec rake
-    - name: Coveralls
+    - name: Send Code Climate coverage
+      uses: aktions/codeclimate-test-reporter@v1
+      with:
+        codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
+        command: after-build --coverage-input-type lcov
+    - name: Send Coveralls coverage
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development, :production do
 end
 
 group :development, :test do
+  gem 'inch', '~> 0.8'
   gem 'pry-awesome_print', '~> 9.6.0'
   gem 'pry-rails',         '~> 0.3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,11 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    inch (0.8.0)
+      pry
+      sparkr (>= 0.2.0)
+      term-ansicolor
+      yard (~> 0.9.12)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -216,6 +221,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.2)
+    sparkr (0.4.1)
     spring (3.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -227,8 +233,13 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
+    sync (0.5.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
     thor (1.1.0)
     thread_safe (0.3.6)
+    tins (1.29.1)
+      sync
     twitter (7.0.0)
       addressable (~> 2.3)
       buftok (~> 0.2.0)
@@ -246,9 +257,12 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (2.1.0)
+    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    yard (0.9.27)
+      webrick (~> 1.7.0)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -257,6 +271,7 @@ PLATFORMS
 DEPENDENCIES
   database_cleaner-active_record (~> 2.0)
   factory_bot (~> 6.2)
+  inch (~> 0.8)
   listen (~> 3.7)
   pg (~> 1.2.3)
   pry-awesome_print (~> 9.6.0)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -5,6 +5,7 @@
 # Represents a vaccine location.
 class Location < ApplicationRecord
   USER_FACING_ATTRIBUTES = %w[name addr1 addr2 link].freeze
+  private_constant :USER_FACING_ATTRIBUTES
 
   alias_attribute :xParent, :x_parent
   alias_attribute :NumChildren, :num_children

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -2,6 +2,7 @@
 
 # Superclass for all services.
 class ApplicationService
+  # Creates and calls the ApplicationService subclass.
   def self.call(...)
     new(...).call
   end

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -3,6 +3,8 @@
 # Superclass for all services.
 class ApplicationService
   # Creates and calls the ApplicationService subclass.
+  #
+  # @return [ApplicationService.new.call]
   def self.call(...)
     new(...).call
   end

--- a/app/services/direct_message_reader.rb
+++ b/app/services/direct_message_reader.rb
@@ -4,11 +4,27 @@
 
 # Reads direct messages for zips that users want to follow.
 class DirectMessageReader < ApplicationService
+  # Creates a DirectMessageReader, setting @direct_messages to the specified array of DM attributes. Defaults to
+  # TWITTER_CLIENT.direct_messages_received in reverse order.
+  #
+  # @param dms [Array] array of DM-attribute hashes
+  # @return [DirectMessageReader]
+  # @example
+  #   DirectMessageReader.new
   def initialize(dms = TWITTER_CLIENT.direct_messages_received.reverse)
     super()
     @direct_messages = dms
   end
 
+  # Reads DMs from the array of DM-attribute hashes @direct_messages.
+  #
+  # @return [Hash] results tallying subscribed and stopped zips
+  # @example
+  #   DirectMessageReader.call
+  #     => {
+  #            :stopped => 13,
+  #         :subscribed => 21
+  #     }
   def call
     results = { stopped: 0, subscribed: 0 }
     @direct_messages.each do |dm|

--- a/app/services/location_syncer.rb
+++ b/app/services/location_syncer.rb
@@ -7,6 +7,7 @@ require 'net/http'
 # Syncs vaccine Locations with LA County's data set.
 class LocationSyncer < ApplicationService
   LA_URL = 'http://publichealth.lacounty.gov/acd/ncorona2019/js/pod-data.js'
+  private_constant :LA_URL
 
   # Creates a LocationSyncer, setting @locations to the specified array of
   # location attributes. Defaults to LA County's locations.

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -5,7 +5,9 @@
 # Notifies users about available Locations in the zips they follow.
 class Notifier < ApplicationService
   DM_HEADER = ['Appointments now available at:', nil].freeze
+  private_constant :DM_HEADER
   DM_FOOTER = "We'll send you updates as soon as we're aware. DM 'stop' to cease notifications."
+  private_constant :DM_FOOTER
 
   # Creates a Notifier, setting @user_zips to the specified array of UserZips.
   # Defaults to all existing UserZips.

--- a/app/services/notify_bot.rb
+++ b/app/services/notify_bot.rb
@@ -7,6 +7,8 @@ require 'net/http'
 # DM users about new Locations.
 class NotifyBot < ApplicationService
   # Calls Notifier.call.
+  #
+  # @return [Notifier.call]
   def call
     Notifier.call if DirectMessageReader.call[:subscribed].positive?
   end

--- a/app/services/notify_bot.rb
+++ b/app/services/notify_bot.rb
@@ -6,6 +6,7 @@ require 'net/http'
 
 # DM users about new Locations.
 class NotifyBot < ApplicationService
+  # Calls Notifier.call.
   def call
     Notifier.call if DirectMessageReader.call[:subscribed].positive?
   end


### PR DESCRIPTION
# Closes: n/a

## Goal
This doesn't replace http://Inch-CI.org (since no equivalent apparently exists), but it does run `inch` on CI as part of the GitHub Action.

## Approach
1. Sync `test.yml` with latest organizational iteration.
2. Add `inch` to `Gemfile`.
3. Have test workflow run `inch --pedantic`.
4. Fix warnings.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
