### PR TITLE
Fix rubocop 1.28.0

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/FetchEnvVar
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+# rubocop:enable Style/FetchEnvVar
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/config/initializers/twitter.rb
+++ b/config/initializers/twitter.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 TWITTER_CLIENT = Twitter::REST::Client.new do |config|
-  config.consumer_key        = ENV['TWITTER_CONSUMER_KEY']
-  config.consumer_secret     = ENV['TWITTER_CONSUMER_SECRET']
-  config.access_token        = ENV['TWITTER_ACCESS_TOKEN']
-  config.access_token_secret = ENV['TWITTER_ACCESS_SECRET']
+  config.consumer_key        = ENV.fetch('TWITTER_CONSUMER_KEY', nil)
+  config.consumer_secret     = ENV.fetch('TWITTER_CONSUMER_SECRET', nil)
+  config.access_token        = ENV.fetch('TWITTER_ACCESS_TOKEN', nil)
+  config.access_token_secret = ENV.fetch('TWITTER_ACCESS_SECRET', nil)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,9 @@ require 'bundler'
 require File.expand_path('support/factory_bot', __dir__)
 
 # rails
+# rubocop:disable Style/FetchEnvVar
 ENV['RAILS_ENV'] ||= 'test'
+# rubocop:enable Style/FetchEnvVar
 require File.expand_path('../config/environment', __dir__)
 require 'rspec/rails'
 


### PR DESCRIPTION
# Closes: n/a

## Goal
Fix failures from #173.

## Approach
1. Disable cop when using `ENV[] ||=`.
2. Run `rubocop -A` for remaining cases.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
