### PR TITLE
conf: rubocop-performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-factory_bot
+  - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
   - rubocop-rspec_rails

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :test do
   gem 'rspec-rails'
   gem 'rubocop'
   gem 'rubocop-factory_bot'
+  gem 'rubocop-performance'
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
   gem 'rubocop-rspec_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,6 +276,9 @@ GEM
       parser (>= 3.3.1.0)
     rubocop-factory_bot (2.26.1)
       rubocop (~> 1.61)
+    rubocop-performance (1.22.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
     rubocop-rails (2.27.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
@@ -377,6 +380,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-factory_bot
+  rubocop-performance
   rubocop-rails
   rubocop-rspec
   rubocop-rspec_rails


### PR DESCRIPTION
# Closes: n/a

## Goal
Help ensure app is performant by installing `rubocop-performance`.

## Approach
1. Add `rubocop-performance` to `.rubocop.yml` and `Gemfile`.

Signed-off-by: Roderick Monje <rod@foveacentral.com>
