### PR TITLE
conf: CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*       rod@foveacentral.com
+
+# Order is important. The last matching pattern has the most precedence.
+# So if a pull request only touches javascript files, only these owners
+# will be requested to review.
+# *.js    @octocat @github/js
+
+# You can also use email addresses if you prefer.
+# docs/*  docs@example.com


### PR DESCRIPTION
# Re: #472

## Goal
Address https://github.com/FoveaCentral/vaccinesignup/security/code-scanning/4.

## Approach
1. Add `CODEOWNERS` as described in [Introducing code owners ](https://github.blog/news-insights/product-news/introducing-code-owners/).

Signed-off-by: Roderick Monje <rod@foveacentral.com>
